### PR TITLE
Resolve a NU1608 warning in the DynamicsConnector.SqlDb.Functions.csproj

### DIFF
--- a/src/DynamicsConnector.Dynamics.Functions/DynamicsConnector.Dynamics.Functions.csproj
+++ b/src/DynamicsConnector.Dynamics.Functions/DynamicsConnector.Dynamics.Functions.csproj
@@ -4,8 +4,8 @@
     <AzureFunctionsVersion>v1</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.ServiceBus" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.ServiceBus" Version="3.0.0-beta8" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DynamicsConnector.Core\DynamicsConnector.Core.csproj" />

--- a/src/DynamicsConnector.SqlDb.Functions/DynamicsConnector.SqlDb.Functions.csproj
+++ b/src/DynamicsConnector.SqlDb.Functions/DynamicsConnector.SqlDb.Functions.csproj
@@ -6,9 +6,9 @@
     <RootNamespace>DynamicsConnector.SqlDb.Functions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DynamicsConnector.Core\DynamicsConnector.Core.csproj" />


### PR DESCRIPTION
Hi@maxmushkin, I found a NU1608 warning in the DynamicsConnector.SqlDb.Functions.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.NET.Sdk.Functions 1.0.26 requires Newtonsoft.Json (= 9.0.1)，but version Newtonsoft.Json 10.0.1 was resolved.`

This fix can remove this warnings from DynamicsConnector's dependency graph.
Hope the PR can help you.

Best regards,
sucrose